### PR TITLE
Remove bold formatting from Scribble title

### DIFF
--- a/doc/png-image.scrbl
+++ b/doc/png-image.scrbl
@@ -2,7 +2,7 @@
 @; png-image.scrbl
 @(require (for-label racket/base racket/contract "../main.rkt"))
 
-@title{@bold{png-image}: Library to view and modify PNG chunks.}
+@title{png-image: Library to view and modify PNG chunks.}
 @author{Lehi Toskin}
 
 @defmodule[png-image]{


### PR DESCRIPTION
For visual consistency with other packages within the docs